### PR TITLE
fix: aws clean-bucket subcommand exists if the bucket is already empty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/sparkfabrik/docker-alpine-aws-cli:2.25.6-alpine3.20 as awscli
+FROM ghcr.io/sparkfabrik/docker-alpine-aws-cli:2.31.17-alpine3.20 AS awscli
 
 FROM alpine:3.20
 

--- a/app/commands/aws/subcommands/clean-bucket.sh
+++ b/app/commands/aws/subcommands/clean-bucket.sh
@@ -37,6 +37,12 @@ fi
 ITEMS_TOT_COUNT=$(jq 'length' <"${ITEMS_TEMP_FILE}")
 echo There are "$(format_string "${ITEMS_TOT_COUNT}" "bold")" items in the bucket.
 
+if [ ${ITEMS_TOT_COUNT} -eq 0 ]; then
+  echo "Bucket is already empty, bailing out."
+  exit 0
+fi
+
+EXIT_CMD=0
 I=0
 until ((I * PAGE_SIZE > ITEMS_TOT_COUNT)); do
   FROM=$((I * PAGE_SIZE))
@@ -59,4 +65,4 @@ done
 rm -f "${ITEMS_TEMP_FILE}"
 
 echo "Objects have been deleted."
-exit "${EXIT_CMD}"
+exit ${EXIT_CMD}


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add early exit when S3 bucket is already empty

- Update AWS CLI Docker base image to version 2.31.17

- Remove unnecessary quotes from exit command variable


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Check bucket items"] --> B{"Items count = 0?"}
  B -- "Yes" --> C["Exit early with success"]
  B -- "No" --> D["Proceed with deletion"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clean-bucket.sh</strong><dd><code>Handle empty bucket case with early exit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/commands/aws/subcommands/clean-bucket.sh

<ul><li>Add check to exit early if bucket is already empty (items count = 0)<br> <li> Remove unnecessary quotes from <code>EXIT_CMD</code> variable in exit statement</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/docker-ops-utils/pull/34/files#diff-257168771512873ca93ded696751e0435b0b85844c3e69ebb98334d28c73be08">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Upgrade AWS CLI Docker base image version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

- Update AWS CLI base image from version 2.25.6 to 2.31.17


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/docker-ops-utils/pull/34/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

